### PR TITLE
geom_alt props

### DIFF
--- a/data/421/188/977/421188977.geojson
+++ b/data/421/188/977/421188977.geojson
@@ -498,6 +498,10 @@
     },
     "wof:country":"FJ",
     "wof:created":1459009595,
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f7dbe715727913e9f95085a81854143",
     "wof:hierarchy":[
         {
@@ -508,7 +512,7 @@
         }
     ],
     "wof:id":421188977,
-    "wof:lastmodified":1566596074,
+    "wof:lastmodified":1582313670,
     "wof:name":"Suva",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/856/327/55/85632755.geojson
+++ b/data/856/327/55/85632755.geojson
@@ -867,6 +867,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -921,6 +922,10 @@
     },
     "wof:country":"FJ",
     "wof:country_alpha3":"FJI",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"7bdc58197e1f43db381155999094ea9c",
     "wof:hierarchy":[
         {
@@ -939,7 +944,7 @@
         "hif",
         "fij"
     ],
-    "wof:lastmodified":1566595961,
+    "wof:lastmodified":1582313667,
     "wof:name":"Fiji",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/327/55/85632755.geojson
+++ b/data/856/327/55/85632755.geojson
@@ -867,7 +867,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -944,7 +943,7 @@
         "hif",
         "fij"
     ],
-    "wof:lastmodified":1582313667,
+    "wof:lastmodified":1583200340,
     "wof:name":"Fiji",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/711/79/85671179.geojson
+++ b/data/856/711/79/85671179.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Northern Division, Fiji"
     },
     "wof:country":"FJ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ecef0493eeb1f9df6f8860831ac52c35",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         "hif",
         "fij"
     ],
-    "wof:lastmodified":1566595963,
+    "wof:lastmodified":1582313668,
     "wof:name":"Northern",
     "wof:parent_id":85632755,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.