### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/102/555/575/102555575.geojson
+++ b/data/102/555/575/102555575.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0637\u0627\u0631 \u0646\u0627\u062f\u064a \u0627\u0644\u062f\u0648\u0644\u064a"
     ],
+    "name:cym_x_preferred":[
+        "Maes Awyr Rhyngwladol Nadi"
+    ],
     "name:deu_x_preferred":[
         "Flughafen Nadi"
     ],
@@ -40,6 +43,9 @@
     ],
     "name:fra_x_preferred":[
         "a\u00e9roport international de Nadi"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e0\u05de\u05dc \u05d4\u05ea\u05e2\u05d5\u05e4\u05d4 \u05d4\u05d1\u05d9\u05e0\u05dc\u05d0\u05d5\u05de\u05d9 \u05e0\u05d0\u05d3\u05d9"
     ],
     "name:hif_x_preferred":[
         "Nadi International Airport"
@@ -86,6 +92,9 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043c\u043e\u0432\u043d\u0442\u043d \u0432\u043b\u0438"
     ],
+    "name:tha_x_preferred":[
+        "\u0e17\u0e48\u0e32\u0e2d\u0e32\u0e01\u0e32\u0e28\u0e22\u0e32\u0e19\u0e19\u0e32\u0e19\u0e32\u0e0a\u0e32\u0e15\u0e34\u0e19\u0e32\u0e14\u0e35"
+    ],
     "name:vie_x_preferred":[
         "S\u00e2n bay qu\u1ed1c t\u1ebf Nadi"
     ],
@@ -123,7 +132,7 @@
         }
     ],
     "wof:id":102555575,
-    "wof:lastmodified":1631743763,
+    "wof:lastmodified":1690879908,
     "wof:name":"Nadi International Airport",
     "wof:parent_id":85671181,
     "wof:placetype":"campus",

--- a/data/112/601/190/1/1126011901.geojson
+++ b/data/112/601/190/1/1126011901.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_preferred":[
         "\u0644\u0627\u0648\u062a\u0648\u0643\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u0627\u0648\u062a\u0648\u0643\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Lautoka"
+    ],
     "name:ben_x_preferred":[
         "\u09b2\u09be\u0989\u099f\u09c1\u0995\u09be"
     ],
@@ -35,6 +41,9 @@
         "Lautoka"
     ],
     "name:ces_x_preferred":[
+        "Lautoka"
+    ],
+    "name:cym_x_preferred":[
         "Lautoka"
     ],
     "name:dan_x_preferred":[
@@ -64,6 +73,12 @@
     "name:fra_x_preferred":[
         "Lautoka"
     ],
+    "name:frr_x_preferred":[
+        "Lautoka"
+    ],
+    "name:gle_x_preferred":[
+        "Lautoka"
+    ],
     "name:glg_x_preferred":[
         "Lautoka"
     ],
@@ -84,6 +99,9 @@
     ],
     "name:hun_x_preferred":[
         "Lautoka"
+    ],
+    "name:hye_x_preferred":[
+        "\u053c\u0561\u0578\u0582\u057f\u0578\u056f\u0561"
     ],
     "name:ind_x_preferred":[
         "Lautoka"
@@ -121,6 +139,9 @@
     "name:nob_x_preferred":[
         "Lautoka"
     ],
+    "name:pih_x_preferred":[
+        "Lautoka"
+    ],
     "name:pol_x_preferred":[
         "Lautoka"
     ],
@@ -140,6 +161,9 @@
         "\u041b\u0430\u0443\u0442\u043e\u043a\u0430"
     ],
     "name:swe_x_preferred":[
+        "Lautoka"
+    ],
+    "name:szl_x_preferred":[
         "Lautoka"
     ],
     "name:tam_x_preferred":[
@@ -206,7 +230,7 @@
         }
     ],
     "wof:id":1126011901,
-    "wof:lastmodified":1636494792,
+    "wof:lastmodified":1690879913,
     "wof:name":"Lautoka",
     "wof:parent_id":85671181,
     "wof:placetype":"locality",

--- a/data/421/174/047/421174047.geojson
+++ b/data/421/174/047/421174047.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Sigatoka"
+    ],
     "name:cat_x_preferred":[
         "Sigatoka"
     ],
@@ -47,6 +50,9 @@
     "name:jpn_x_preferred":[
         "\u30b7\u30f3\u30ac\u30c8\u30ab"
     ],
+    "name:kor_x_preferred":[
+        "\uc2f1\uc544\ud1a0\uce74"
+    ],
     "name:lit_x_preferred":[
         "Sigatoka"
     ],
@@ -70,6 +76,9 @@
     ],
     "name:und_x_variant":[
         "Nasigatoka"
+    ],
+    "name:zho_x_preferred":[
+        "\u8f9b\u52a0\u6771\u5361"
     ],
     "qs:gn_country":"FJ",
     "qs:gn_fcode":"PPL",
@@ -115,7 +124,7 @@
         }
     ],
     "wof:id":421174047,
-    "wof:lastmodified":1566596073,
+    "wof:lastmodified":1690879912,
     "wof:name":"Singatoka",
     "wof:parent_id":85671181,
     "wof:placetype":"locality",

--- a/data/421/174/677/421174677.geojson
+++ b/data/421/174/677/421174677.geojson
@@ -436,6 +436,9 @@
     "name:ruq_x_preferred":[
         "Korovou"
     ],
+    "name:rus_x_preferred":[
+        "\u041a\u043e\u0440\u043e\u0432\u043e\u0443"
+    ],
     "name:sag_x_preferred":[
         "Korovou"
     ],
@@ -625,7 +628,7 @@
         }
     ],
     "wof:id":421174677,
-    "wof:lastmodified":1566596073,
+    "wof:lastmodified":1690879912,
     "wof:name":"Korovou",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/179/869/421179869.geojson
+++ b/data/421/179/869/421179869.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0646\u0627\u062f\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0646\u0627\u062f\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Nadi"
+    ],
     "name:ben_x_preferred":[
         "\u09a8\u09be\u09a8\u09cd\u09a6\u09bf"
     ],
@@ -27,6 +33,9 @@
         "Nadi"
     ],
     "name:ces_x_preferred":[
+        "Nadi"
+    ],
+    "name:cym_x_preferred":[
         "Nadi"
     ],
     "name:deu_x_preferred":[
@@ -50,6 +59,9 @@
     "name:fra_x_preferred":[
         "Nadi"
     ],
+    "name:heb_x_preferred":[
+        "\u05e0\u05d0\u05d3\u05d9"
+    ],
     "name:hif_x_preferred":[
         "Nadi"
     ],
@@ -58,6 +70,9 @@
     ],
     "name:hun_x_preferred":[
         "Nandi"
+    ],
+    "name:hye_x_preferred":[
+        "\u0546\u0561\u0564\u056b"
     ],
     "name:ind_x_preferred":[
         "Nandi"
@@ -80,7 +95,13 @@
     "name:lit_x_preferred":[
         "Nadis"
     ],
+    "name:mya_x_preferred":[
+        "\u1014\u1012\u102e\u1019\u103c\u102d\u102f\u1037"
+    ],
     "name:nld_x_preferred":[
+        "Nadi"
+    ],
+    "name:pih_x_preferred":[
         "Nadi"
     ],
     "name:pol_x_preferred":[
@@ -107,11 +128,17 @@
     "name:tur_x_preferred":[
         "Nandi"
     ],
+    "name:ukr_x_preferred":[
+        "\u041d\u0430\u043d\u0434\u0456"
+    ],
     "name:urd_x_preferred":[
         "\u0646\u0646\u062f\u06cc"
     ],
     "name:vie_x_preferred":[
         "Nandi"
+    ],
+    "name:war_x_preferred":[
+        "Nadi"
     ],
     "name:zho_x_preferred":[
         "\u6960\u8fea"
@@ -256,7 +283,7 @@
         }
     ],
     "wof:id":421179869,
-    "wof:lastmodified":1636494792,
+    "wof:lastmodified":1690879913,
     "wof:name":"Nandi",
     "wof:parent_id":85671181,
     "wof:placetype":"locality",

--- a/data/421/182/685/421182685.geojson
+++ b/data/421/182/685/421182685.geojson
@@ -20,14 +20,26 @@
     "name:ara_x_preferred":[
         "\u0644\u0627\u0628\u0627\u0633\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u0627\u0628\u0627\u0633\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Labasa"
+    ],
     "name:bul_x_preferred":[
         "\u041b\u0430\u043c\u0431\u0430\u0441\u0430"
     ],
     "name:ceb_x_preferred":[
         "Lambasa"
     ],
+    "name:ces_x_preferred":[
+        "Labasa"
+    ],
     "name:deu_x_preferred":[
         "Labasa"
+    ],
+    "name:ell_x_preferred":[
+        "\u039b\u03b1\u03bc\u03c0\u03ac\u03c3\u03b1"
     ],
     "name:eng_x_preferred":[
         "Labasa"
@@ -39,6 +51,9 @@
         "Labasa"
     ],
     "name:fra_x_preferred":[
+        "Labasa"
+    ],
+    "name:frr_x_preferred":[
         "Labasa"
     ],
     "name:heb_x_preferred":[
@@ -77,6 +92,9 @@
     "name:nor_x_preferred":[
         "Labasa"
     ],
+    "name:pih_x_preferred":[
+        "Labasa"
+    ],
     "name:pol_x_preferred":[
         "Labasa"
     ],
@@ -88,6 +106,9 @@
     ],
     "name:san_x_preferred":[
         "\u0932\u092c\u0938"
+    ],
+    "name:slk_x_preferred":[
+        "Labasa"
     ],
     "name:spa_x_preferred":[
         "Labasa"
@@ -103,6 +124,9 @@
     ],
     "name:zho_x_preferred":[
         "\u62c9\u5df4\u8428"
+    ],
+    "name:zho_x_variant":[
+        "\u5170\u5df4\u8428"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Fiji",
@@ -244,7 +268,7 @@
         }
     ],
     "wof:id":421182685,
-    "wof:lastmodified":1566596074,
+    "wof:lastmodified":1690879913,
     "wof:name":"Lambase",
     "wof:parent_id":85671179,
     "wof:placetype":"locality",

--- a/data/421/185/391/421185391.geojson
+++ b/data/421/185/391/421185391.geojson
@@ -29,11 +29,17 @@
     "name:hif_x_preferred":[
         "Navua"
     ],
+    "name:jpn_x_preferred":[
+        "\u30ca\u30f4\u30a2"
+    ],
     "name:nld_x_preferred":[
         "Navua"
     ],
     "name:pol_x_preferred":[
         "Navua"
+    ],
+    "name:rus_x_preferred":[
+        "\u041d\u0430\u0432\u0443\u0430"
     ],
     "qs:gn_country":"FJ",
     "qs:gn_fcode":"PPL",
@@ -78,7 +84,7 @@
         }
     ],
     "wof:id":421185391,
-    "wof:lastmodified":1566596074,
+    "wof:lastmodified":1690879913,
     "wof:name":"Navua",
     "wof:parent_id":85671167,
     "wof:placetype":"locality",

--- a/data/421/188/977/421188977.geojson
+++ b/data/421/188/977/421188977.geojson
@@ -31,7 +31,16 @@
     "name:ara_x_preferred":[
         "\u0633\u0648\u0641\u0627"
     ],
+    "name:ary_x_preferred":[
+        "\u0633\u0648\u06a4\u0627"
+    ],
+    "name:arz_x_preferred":[
+        "\u0633\u0648\u0641\u0627"
+    ],
     "name:ast_x_preferred":[
+        "Suva"
+    ],
+    "name:avk_x_preferred":[
         "Suva"
     ],
     "name:aze_x_preferred":[
@@ -39,6 +48,9 @@
     ],
     "name:bak_x_preferred":[
         "\u0421\u0443\u0432\u0430"
+    ],
+    "name:ban_x_preferred":[
+        "Suva"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u0443\u0432\u0430"
@@ -107,6 +119,9 @@
         "Suva"
     ],
     "name:fra_x_preferred":[
+        "Suva"
+    ],
+    "name:frr_x_preferred":[
         "Suva"
     ],
     "name:fry_x_preferred":[
@@ -217,6 +232,9 @@
     "name:mon_x_preferred":[
         "\u0421\u0443\u0432\u0430"
     ],
+    "name:mri_x_preferred":[
+        "Huwha"
+    ],
     "name:msa_x_preferred":[
         "Suva"
     ],
@@ -253,6 +271,12 @@
     "name:pan_x_preferred":[
         "\u0a38\u0a42\u0a35\u0a3e"
     ],
+    "name:pap_x_preferred":[
+        "Suva"
+    ],
+    "name:pih_x_preferred":[
+        "Suva"
+    ],
     "name:pms_x_preferred":[
         "Suva"
     ],
@@ -265,6 +289,9 @@
     "name:por_x_preferred":[
         "Suva"
     ],
+    "name:pus_x_preferred":[
+        "\u0633\u0648\u0648\u0627"
+    ],
     "name:ron_x_preferred":[
         "Suva"
     ],
@@ -273,6 +300,9 @@
     ],
     "name:sah_x_preferred":[
         "\u0421\u0443\u0432\u0430"
+    ],
+    "name:sat_x_preferred":[
+        "\u1c65\u1c69\u1c75\u1c77\u1c5f"
     ],
     "name:sco_x_preferred":[
         "Suva"
@@ -295,6 +325,9 @@
     "name:sqi_x_preferred":[
         "Suva"
     ],
+    "name:srd_x_preferred":[
+        "Suva"
+    ],
     "name:srp_x_preferred":[
         "\u0421\u0443\u0432\u0430"
     ],
@@ -302,6 +335,9 @@
         "Suva"
     ],
     "name:swe_x_preferred":[
+        "Suva"
+    ],
+    "name:szl_x_preferred":[
         "Suva"
     ],
     "name:tah_x_preferred":[
@@ -312,6 +348,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c38\u0c42\u0c35\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0421\u0443\u0432\u0430"
     ],
     "name:tgl_x_preferred":[
         "Suva"
@@ -348,6 +387,9 @@
     ],
     "name:war_x_preferred":[
         "Suva"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10e1\u10e3\u10d5\u10d0"
     ],
     "name:yue_x_preferred":[
         "\u8607\u74e6"
@@ -514,7 +556,7 @@
         }
     ],
     "wof:id":421188977,
-    "wof:lastmodified":1607390897,
+    "wof:lastmodified":1690879912,
     "wof:name":"Suva",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/856/327/55/85632755.geojson
+++ b/data/856/327/55/85632755.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":8.0,
     "mz:min_zoom":3.0,
+    "name:abk_x_preferred":[
+        "\u0424\u0438\u045f\u044c\u0438"
+    ],
     "name:ace_x_preferred":[
         "Fiji"
     ],
@@ -37,17 +40,26 @@
     "name:aka_x_preferred":[
         "Figyi"
     ],
+    "name:aka_x_variant":[
+        "Fiji"
+    ],
     "name:als_x_preferred":[
         "Fidschi"
     ],
     "name:amh_x_preferred":[
         "\u134a\u1302"
     ],
+    "name:ami_x_preferred":[
+        "Fiji"
+    ],
     "name:ang_x_preferred":[
         "Ficg\u012bege"
     ],
     "name:ang_x_variant":[
         "Ficgiege"
+    ],
+    "name:anp_x_preferred":[
+        "\u092b\u0940\u091c\u0940"
     ],
     "name:ara_x_preferred":[
         "\u0641\u064a\u062c\u064a"
@@ -66,6 +78,9 @@
     ],
     "name:ast_x_variant":[
         "Islles Fixi"
+    ],
+    "name:avk_x_preferred":[
+        "Vitia"
     ],
     "name:azb_x_preferred":[
         "\u0641\u06cc\u062c\u06cc"
@@ -93,6 +108,9 @@
     ],
     "name:bho_x_preferred":[
         "\u092b\u093f\u091c\u0940"
+    ],
+    "name:bis_x_preferred":[
+        "Fiji"
     ],
     "name:bod_x_preferred":[
         "\u0f67\u0fa5\u0f72\u0f0b\u0f47\u0f72\u0f0d"
@@ -133,6 +151,9 @@
     "name:chv_x_preferred":[
         "\u0424\u0438\u0434\u0436\u0438"
     ],
+    "name:chy_x_preferred":[
+        "Fiji"
+    ],
     "name:ckb_x_preferred":[
         "\u0641\u06cc\u062c\u06cc"
     ],
@@ -146,6 +167,9 @@
         "Ffiji"
     ],
     "name:cym_x_variant":[
+        "Fiji"
+    ],
+    "name:dag_x_preferred":[
         "Fiji"
     ],
     "name:dan_x_preferred":[
@@ -281,6 +305,9 @@
     ],
     "name:gom_x_preferred":[
         "\u092b\u093f\u091c\u0940"
+    ],
+    "name:gpe_x_preferred":[
+        "Fiji"
     ],
     "name:grn_x_preferred":[
         "F\u00edji"
@@ -446,6 +473,9 @@
     "name:lit_x_preferred":[
         "Fid\u017eis"
     ],
+    "name:lld_x_preferred":[
+        "Fiji"
+    ],
     "name:lmo_x_preferred":[
         "Figi"
     ],
@@ -470,6 +500,9 @@
     "name:mar_x_preferred":[
         "\u092b\u093f\u091c\u0940"
     ],
+    "name:mhr_x_preferred":[
+        "\u0424\u0438\u0434\u0436\u0438"
+    ],
     "name:min_x_preferred":[
         "Fiji"
     ],
@@ -484,6 +517,9 @@
     ],
     "name:mlt_x_preferred":[
         "Fi\u0121i"
+    ],
+    "name:mni_x_preferred":[
+        "\uabd0\uabe4\uabd6\uabe4"
     ],
     "name:mon_x_preferred":[
         "\u0424\u0438\u0436\u0438"
@@ -593,6 +629,9 @@
     "name:pus_x_preferred":[
         "\u0641\u06d0\u062c\u064a"
     ],
+    "name:pus_x_variant":[
+        "\u0641\u062c\u064a \u062c\u0645\u0647\u0648\u0631\u064a\u062a"
+    ],
     "name:que_x_preferred":[
         "Phiyi"
     ],
@@ -629,6 +668,9 @@
     "name:sgs_x_preferred":[
         "F\u0117d\u017eis"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u107e\u102e\u1087\u1075\u103b\u102e\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0dc6\u0dd3\u0da2\u0dd2"
     ],
@@ -644,8 +686,14 @@
     "name:sme_x_preferred":[
         "Fi\u017ei"
     ],
+    "name:smn_x_preferred":[
+        "Fid\u017ei"
+    ],
     "name:smo_x_preferred":[
         "Fiti"
+    ],
+    "name:sms_x_preferred":[
+        "Fid\u017ei"
     ],
     "name:sna_x_preferred":[
         "Fiji"
@@ -707,6 +755,9 @@
     "name:tat_x_variant":[
         "Fiji"
     ],
+    "name:tay_x_preferred":[
+        "Fiji"
+    ],
     "name:tel_x_preferred":[
         "\u0c2b\u0c3f\u0c1c\u0c40"
     ],
@@ -732,6 +783,9 @@
     "name:tir_x_preferred":[
         "\u134a\u1302"
     ],
+    "name:tok_x_preferred":[
+        "ma Pisi"
+    ],
     "name:ton_x_preferred":[
         "Fisi"
     ],
@@ -741,11 +795,17 @@
     "name:tpi_x_preferred":[
         "Fiji"
     ],
+    "name:trv_x_preferred":[
+        "Fiji"
+    ],
     "name:tuk_x_preferred":[
         "Fiji"
     ],
     "name:tur_x_preferred":[
         "Fiji"
+    ],
+    "name:udm_x_preferred":[
+        "\u0424\u0438\u0434\u0436\u0438"
     ],
     "name:uig_x_preferred":[
         "\u0641\u0649\u062c\u0649"
@@ -771,6 +831,9 @@
     ],
     "name:vec_x_preferred":[
         "Fi\u0121i"
+    ],
+    "name:vec_x_variant":[
+        "Fizi"
     ],
     "name:vep_x_preferred":[
         "Fid\u017ei"
@@ -1054,7 +1117,7 @@
         "hif",
         "fij"
     ],
-    "wof:lastmodified":1617827368,
+    "wof:lastmodified":1690879909,
     "wof:name":"Fiji",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/711/67/85671167.geojson
+++ b/data/856/711/67/85671167.geojson
@@ -76,6 +76,9 @@
     "name:fra_x_variant":[
         "division centrale"
     ],
+    "name:frr_x_preferred":[
+        "Central"
+    ],
     "name:glg_x_preferred":[
         "Divisi\u00f3n Central"
     ],
@@ -138,6 +141,9 @@
     ],
     "name:nor_x_preferred":[
         "Sentral-Fiji"
+    ],
+    "name:pan_x_preferred":[
+        "\u0a15\u0a47\u0a02\u0a26\u0a30\u0a40 \u0a35\u0a70\u0a21"
     ],
     "name:pol_x_preferred":[
         "Dystrykt Centralny"
@@ -307,7 +313,7 @@
         "hif",
         "fij"
     ],
-    "wof:lastmodified":1636494790,
+    "wof:lastmodified":1690879910,
     "wof:name":"Central",
     "wof:parent_id":85632755,
     "wof:placetype":"region",

--- a/data/856/711/73/85671173.geojson
+++ b/data/856/711/73/85671173.geojson
@@ -72,6 +72,9 @@
     "name:fra_x_preferred":[
         "Division orientale"
     ],
+    "name:frr_x_preferred":[
+        "Eastern"
+    ],
     "name:glg_x_preferred":[
         "Divisi\u00f3n Oriental"
     ],
@@ -137,6 +140,9 @@
     ],
     "name:por_x_preferred":[
         "Divis\u00e3o do Leste"
+    ],
+    "name:ron_x_preferred":[
+        "Diviziunea Oriental\u0103"
     ],
     "name:rus_x_preferred":[
         "\u0412\u043e\u0441\u0442\u043e\u0447\u043d\u044b\u0439 \u043e\u043a\u0440\u0443\u0433"
@@ -307,7 +313,7 @@
         "hif",
         "fij"
     ],
-    "wof:lastmodified":1636494790,
+    "wof:lastmodified":1690879910,
     "wof:name":"Eastern",
     "wof:parent_id":85632755,
     "wof:placetype":"region",

--- a/data/856/711/79/85671179.geojson
+++ b/data/856/711/79/85671179.geojson
@@ -76,6 +76,9 @@
     "name:fra_x_variant":[
         "division septentrionale"
     ],
+    "name:frr_x_preferred":[
+        "Northern"
+    ],
     "name:glg_x_preferred":[
         "Divisi\u00f3n Norte"
     ],
@@ -159,6 +162,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0bb5\u0b9f\u0b95\u0bcd\u0b95\u0bc1  \u0b9f\u0bbf\u0bb5\u0bbf\u0b9a\u0ba9\u0bcd"
+    ],
+    "name:tam_x_variant":[
+        "\u0bb5\u0b9f\u0b95\u0bcd\u0b95\u0bc1 \u0b9f\u0bbf\u0bb5\u0bbf\u0b9a\u0ba9\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c09\u0c24\u0c4d\u0c24\u0c30\u0c3e \u0c21\u0c3f\u0c35\u0c3f\u0c1c\u0c28\u0c4d"
@@ -309,7 +315,7 @@
         "hif",
         "fij"
     ],
-    "wof:lastmodified":1636494790,
+    "wof:lastmodified":1690879911,
     "wof:name":"Northern",
     "wof:parent_id":85632755,
     "wof:placetype":"region",

--- a/data/856/711/81/85671181.geojson
+++ b/data/856/711/81/85671181.geojson
@@ -70,6 +70,9 @@
     "name:fra_x_variant":[
         "division occidentale"
     ],
+    "name:frr_x_preferred":[
+        "Western"
+    ],
     "name:glg_x_preferred":[
         "Divisi\u00f3n Occidental"
     ],
@@ -133,6 +136,9 @@
     "name:por_x_preferred":[
         "Divis\u00e3o do Oeste"
     ],
+    "name:ron_x_preferred":[
+        "Diviziunea Occidental\u0103"
+    ],
     "name:rus_x_preferred":[
         "\u0417\u0430\u043f\u0430\u0434\u043d\u044b\u0439 \u043e\u043a\u0440\u0443\u0433"
     ],
@@ -147,6 +153,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0bae\u0bc7\u0bb1\u0bcd\u0b95\u0bc1  \u0b9f\u0bbf\u0bb5\u0bbf\u0b9a\u0ba9\u0bcd"
+    ],
+    "name:tam_x_variant":[
+        "\u0bae\u0bc7\u0bb1\u0bcd\u0b95\u0bc1 \u0b9f\u0bbf\u0bb5\u0bbf\u0b9a\u0ba9\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c2a\u0c36\u0c4d\u0c1a\u0c3f\u0c2e \u0c21\u0c3f\u0c35\u0c3f\u0c1c\u0c28\u0c4d"
@@ -301,7 +310,7 @@
         "hif",
         "fij"
     ],
-    "wof:lastmodified":1636494790,
+    "wof:lastmodified":1690879910,
     "wof:name":"Western",
     "wof:parent_id":85632755,
     "wof:placetype":"region",

--- a/data/856/711/85/85671185.geojson
+++ b/data/856/711/85/85671185.geojson
@@ -39,6 +39,9 @@
     "name:ast_x_preferred":[
         "Rotuma"
     ],
+    "name:aze_x_preferred":[
+        "Rotuma"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0420\u0430\u0442\u0443\u043c\u0430"
     ],
@@ -120,6 +123,9 @@
     "name:jpn_x_preferred":[
         "\u30ed\u30c4\u30de\u5c5e\u9818"
     ],
+    "name:jpn_x_variant":[
+        "\u30ed\u30c4\u30de"
+    ],
     "name:kan_x_preferred":[
         "\u0cb0\u0cca\u0c9f\u0cc1\u0cae\u0cbe"
     ],
@@ -130,7 +136,8 @@
         "\ub85c\ud22c\ub9c8 \uc12c"
     ],
     "name:kor_x_variant":[
-        "\ub85c\ud22c\ub9c8\uc12c"
+        "\ub85c\ud22c\ub9c8\uc12c",
+        "\ub85c\ud22c\ub9c8"
     ],
     "name:lav_x_preferred":[
         "Rotuma"
@@ -343,7 +350,7 @@
         "hif",
         "fij"
     ],
-    "wof:lastmodified":1636494790,
+    "wof:lastmodified":1690879911,
     "wof:name":"Rotuma",
     "wof:parent_id":85632755,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.