### PR TITLE
fj concordances, placetype local, and more

### DIFF
--- a/data/856/327/55/85632755.geojson
+++ b/data/856/327/55/85632755.geojson
@@ -1084,6 +1084,7 @@
         "hasc:id":"FJ",
         "icao:code":"DQ",
         "ioc:id":"FIJ",
+        "iso:code":"FJ",
         "itu:id":"FJI",
         "m49:code":"242",
         "marc:id":"fj",
@@ -1097,6 +1098,7 @@
         "wk:page":"Fiji",
         "wmo:id":"FJ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"FJ",
     "wof:country_alpha3":"FJI",
     "wof:geom_alt":[
@@ -1121,7 +1123,7 @@
         "hif",
         "fij"
     ],
-    "wof:lastmodified":1694639498,
+    "wof:lastmodified":1695881152,
     "wof:name":"Fiji",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/711/67/85671167.geojson
+++ b/data/856/711/67/85671167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.389534,
-    "geom:area_square_m":4582368073.540757,
+    "geom:area_square_m":4582368285.963634,
     "geom:bbox":"177.768199,-18.41546,178.711436,-17.550258",
     "geom:latitude":-17.943459,
     "geom:longitude":178.24127,
@@ -286,14 +286,16 @@
         "gn:id":2205272,
         "gp:id":2345335,
         "hasc:id":"FJ.CE",
+        "iso:code":"FJ-C",
         "iso:id":"FJ-C",
         "qs_pg:id":219552,
         "unlc:id":"FJ-C",
         "wd:id":"Q1053789",
         "wk:page":"Central Division, Fiji"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"FJ",
-    "wof:geomhash":"bd8a6eb786acbd17f8fa4e5e882e6faf",
+    "wof:geomhash":"ee3343b5fcee1b6703a5065657de6416",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -313,7 +315,7 @@
         "hif",
         "fij"
     ],
-    "wof:lastmodified":1690879910,
+    "wof:lastmodified":1695884775,
     "wof:name":"Central",
     "wof:parent_id":85632755,
     "wof:placetype":"region",

--- a/data/856/711/73/85671173.geojson
+++ b/data/856/711/73/85671173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.120213,
-    "geom:area_square_m":1410515932.919954,
+    "geom:area_square_m":1410515231.747833,
     "geom:bbox":"-179.871938,-20.671808,179.952403,-17.149102",
     "geom:latitude":-18.38169,
     "geom:longitude":80.06169,
@@ -286,14 +286,16 @@
         "gn:id":4036647,
         "gp:id":2345336,
         "hasc:id":"FJ.EA",
+        "iso:code":"FJ-E",
         "iso:id":"FJ-E",
         "qs_pg:id":1135044,
         "unlc:id":"FJ-E",
         "wd:id":"Q182169",
         "wk:page":"Eastern Division, Fiji"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"FJ",
-    "wof:geomhash":"06776046a11edd4e2fcd1417d8241f86",
+    "wof:geomhash":"fb3f30e2e65e5312df6e3810d789db82",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -313,7 +315,7 @@
         "hif",
         "fij"
     ],
-    "wof:lastmodified":1690879910,
+    "wof:lastmodified":1695884775,
     "wof:name":"Eastern",
     "wof:parent_id":85632755,
     "wof:placetype":"region",

--- a/data/856/711/79/85671179.geojson
+++ b/data/856/711/79/85671179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.537998,
-    "geom:area_square_m":1055337976126.958496,
+    "geom:area_square_m":6374820440.19994,
     "geom:bbox":"-180.0,-17.007013,180.0,-15.711196",
     "geom:latitude":-16.610172,
     "geom:longitude":155.445535,
@@ -285,17 +285,19 @@
         "gn:id":2199295,
         "gp:id":2345337,
         "hasc:id":"FJ.NO",
+        "iso:code":"FJ-N",
         "iso:id":"FJ-N",
         "qs_pg:id":235594,
         "unlc:id":"FJ-N",
         "wd:id":"Q1062430",
         "wk:page":"Northern Division, Fiji"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"FJ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e86d1ec179fbc16adddce5e8999409b8",
+    "wof:geomhash":"85f9c79d7a36c9b3d0660128170c8936",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -315,7 +317,7 @@
         "hif",
         "fij"
     ],
-    "wof:lastmodified":1690879911,
+    "wof:lastmodified":1695884775,
     "wof:name":"Northern",
     "wof:parent_id":85632755,
     "wof:placetype":"region",

--- a/data/856/711/81/85671181.geojson
+++ b/data/856/711/81/85671181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.56048,
-    "geom:area_square_m":6601107121.710375,
+    "geom:area_square_m":6601108616.169879,
     "geom:bbox":"174.588878,-21.711114,178.448622,-16.676853",
     "geom:latitude":-17.731542,
     "geom:longitude":177.763521,
@@ -283,14 +283,16 @@
         "gn:id":2194371,
         "gp:id":2345338,
         "hasc:id":"FJ.WE",
+        "iso:code":"FJ-W",
         "iso:id":"FJ-W",
         "qs_pg:id":901862,
         "unlc:id":"FJ-W",
         "wd:id":"Q1062451",
         "wk:page":"Western Division, Fiji"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"FJ",
-    "wof:geomhash":"d112cc03275a7410a495daabd392930e",
+    "wof:geomhash":"6a1f70f25463f34c638fdf249820db2d",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -310,7 +312,7 @@
         "hif",
         "fij"
     ],
-    "wof:lastmodified":1690879910,
+    "wof:lastmodified":1695884775,
     "wof:name":"Western",
     "wof:parent_id":85632755,
     "wof:placetype":"region",

--- a/data/856/711/85/85671185.geojson
+++ b/data/856/711/85/85671185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003288,
-    "geom:area_square_m":39696845.973751,
+    "geom:area_square_m":39696992.643439,
     "geom:bbox":"177.00587,-12.51686,177.12908,-12.475274",
     "geom:latitude":-12.497272,
     "geom:longitude":177.07312,
@@ -324,14 +324,16 @@
         "gn:id":6324593,
         "gp:id":20069921,
         "hasc:id":"FJ.RO",
+        "iso:code":"FJ-R",
         "iso:id":"FJ-R",
         "qs_pg:id":1172802,
         "unlc:id":"FJ-R",
         "wd:id":"Q459763",
         "wk:page":"Rotuma"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"FJ",
-    "wof:geomhash":"13ed1180aea1fabcc55fe7de6511ff1e",
+    "wof:geomhash":"f120025ee228046384e43506c796e43e",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -350,7 +352,7 @@
         "hif",
         "fij"
     ],
-    "wof:lastmodified":1690879911,
+    "wof:lastmodified":1695884775,
     "wof:name":"Rotuma",
     "wof:parent_id":85632755,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.